### PR TITLE
Le code fait muter les informations dans RecruiterRepository

### DIFF
--- a/src/test/java/use_case/PlanInterviewShould.java
+++ b/src/test/java/use_case/PlanInterviewShould.java
@@ -36,4 +36,14 @@ public class PlanInterviewShould {
         // WHEN
         return interview.plan(candidateId, interviewDate);
     }
+
+    @Test
+    void mutates_data_inside_recruiter_repository() {
+        final FakeRecruiters recruitersRepository = new FakeRecruiters();
+        PlanInterview interview = new PlanInterview(new FakeCandidates(), recruitersRepository, new FakeInterview());
+
+        interview.plan("123", of(2021, 2, 20));
+
+        Assertions.assertThat(recruitersRepository.recruiters).isEqualTo(new FakeRecruiters().recruiters);
+    }
 }


### PR DESCRIPTION
Si j'ai bien compris, on voudrait éviter de planifier deux entretiens avec le même recruteur en même temps (d'où l'information à propos de la disponibilité `availabilities`).
Le code actuel fait muter les informations qui sont dans le RecruiterRepository et du coup effectivement on ne peut pas planifier deux entretiens pour le même recruteur en même temps. Mais cette mutation est uniquement faite "in memory" et n'est jamais persistée : si l'application redemarre, alors on pourra alors replanifier un entretien pour un recruteur sur un créneau déjà utilisé.

=> Dans une vrai application, pour corriger ce problème il faudrait :
* soit effectuer un `RecruiterRepository.save()` pour conserver cette mutation
* soit utiliser les informations dans InterviewRepository pour calculer les disponibilités déjà occupées pour le recruiter qui vient du `RecruiterRepository`

A mon avis, si on utilise uniquement un repository pour les aggregats, alors les autres repositories devraient être considérés comme des "référentiels" et donc toutes les données devraient être complètement immutables dedans et on ne devrait jamais se permettre d'utiliser des fonctions qui font muter les objets comme [`remove`](https://github.com/SepehrNamdar/sandwich-driven-development/blob/alpes_craft/src/main/java/model/Interview.java#L26)

Ca ne change rien à la démonstration de la méthode du sandwich mais je trouve que ce petit problème dessert la présentation : les gens vont se concentrer dessus comme je viens de faire alors que ce n'est pas l'objectif :/